### PR TITLE
don't start monit until config file is dropped in

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -85,7 +85,7 @@ end
 
 service "monit" do
   supports :status => true, :restart => true, :reload => true
-  action [:enable, :start]
+  action [:enable]
 end
 
 template node["monit"]["config_file"] do


### PR DESCRIPTION
addresses [DE87]
closes rcbops-cookbooks/monit#17
