### PR TITLE
Accept HTTP checks for monit_procmon

### DIFF
--- a/resources/procmon.rb
+++ b/resources/procmon.rb
@@ -30,3 +30,4 @@ attribute :service_bin, :kind_of => String
 attribute :script_name, :kind_of => String
 attribute :start_cmd, :kind_of => String
 attribute :stop_cmd, :kind_of => String
+attribute :http_check, :kind_of => [Array, Hash]

--- a/templates/default/procmon.erb
+++ b/templates/default/procmon.erb
@@ -10,4 +10,7 @@ check process <%= @identifier %> matching "<%= @process_name %>"
 <% end %>
   start program = "<%= @service_bin -%> <%= @script_name %> <%= @start_cmd %>"
   stop program = "<%= @service_bin -%> <%= @script_name %> <%= @stop_cmd %>"
+<% @http_checks.each do |check| -%>
+  <%= check %>
+<% end -%>
   if 5 restarts within 5 cycles then timeout


### PR DESCRIPTION
Allows for passing HTTP checks to monit_procmon which are then
added to the Monit configuration file for that process. e.g.:

``` ruby
monit_procmon "keystone" do
  procname platform_options["keystone_service"]
  sname platform_options["keystone_process_name"]
  process_name sname
  script_name procname
  http_check [
    {
      :host => "localhost",
      :port => 5000
    },
    {
      :host => "localhost",
      :port => 35357
    }
  ]
end
```
