### PR TITLE
Be more idiomatic when ensuring arrays

### DIFF
--- a/providers/procmon.rb
+++ b/providers/procmon.rb
@@ -47,7 +47,7 @@ action :add do
     stop_cmd = "stop"
   end
 
-  http_checks = ensure_array(new_resource.http_check).compact.map do |check|
+  http_checks = Array(new_resource.http_check).map do |check|
     create_http_check(check)
   end
 
@@ -74,10 +74,6 @@ action :add do
 end
 
 private
-
-def ensure_array(obj)
-  obj.is_a?(Array) ? obj : [obj]
-end
 
 def create_http_check(check)
   check[:host] ||= "localhost"


### PR DESCRIPTION
Convert the variable into an Array object instead of checking if it's an Array. This has the same outputs with the added benefit of compacting out the nils for you, and being prettier.
