### PR TITLE
Disable service reload for RHEL

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -47,7 +47,11 @@ directory "/var/lib/monit" do
 end
 
 service "monit" do
-  supports :status => true, :restart => true, :reload => true
+  supports value_for_platform_family(
+    "rhel" => { "default" => [:status, :restart] },
+    "default" => { "default" => [:status, :restart, :reload] }
+  )
+
   action [:enable]
 end
 


### PR DESCRIPTION
Chef attempts to restart the monit service using the reload command but it's
not supported on RHEL. Tweak supports to be platform_family aware.

Fixes rcbops/chef-cookbooks#669
