### PR TITLE
Change to :delayed restarts for procmon resource

### DIFF
--- a/providers/procmon.rb
+++ b/providers/procmon.rb
@@ -75,7 +75,7 @@ action :add do
       "http_checks" => http_checks
     )
     action :create
-    notifies :reload, "service[monit]", :immediately
+    notifies :reload, "service[monit]", :delayed
   end
   new_resource.updated_by_last_action(r.updated_by_last_action?)
 end


### PR DESCRIPTION
We're seeing a lot of monit service restarts on a typical OpenStack/HA 
deployment. These have been set to :immediately since the inception of this
cookbook.
- Change :immediately to :delayed for monit service notification in
  procmon
