### PR TITLE
Restart monit after remove action

### DIFF
--- a/providers/procmon.rb
+++ b/providers/procmon.rb
@@ -20,6 +20,7 @@
 action :remove do
   r = file "#{node['monit']['conf.d_dir']}/#{new_resource.name}.conf" do
     action :delete
+    notifies :restart, "service[monit]", :delayed
   end
   new_resource.updated_by_last_action(r.updated_by_last_action?)
 end


### PR DESCRIPTION
Restart monit when removing files from monit conf.d. A reload is right out.

See rcbops/chef-cookbooks#722
