### PR TITLE
Allow empty settings to disable start/stop program

### DIFF
--- a/providers/procmon.rb
+++ b/providers/procmon.rb
@@ -73,7 +73,9 @@ action :add do
       "service_bin" => service_bin,
       "stop_cmd" => stop_cmd,
       "start_cmd" => start_cmd,
-      "http_checks" => http_checks.sort
+      "http_checks" => http_checks.sort,
+      "start_program" => "#{new_resource.service_bin} #{new_resource.script_name} #{new_resource.start_cmd}".strip,
+      "stop_program" => "#{new_resource.service_bin} #{new_resource.script_name} #{new_resource.stop_cmd}".strip
     )
     action :create
     notifies :restart, "service[monit]", :delayed

--- a/templates/default/procmon.erb
+++ b/templates/default/procmon.erb
@@ -8,8 +8,12 @@ check process <%= @identifier %> pidfile "<%= @pid_file %>"
 <% else %>
 check process <%= @identifier %> matching "<%= @process_name %>"
 <% end %>
-  start program = "<%= @service_bin -%> <%= @script_name %> <%= @start_cmd %>"
-  stop program = "<%= @service_bin -%> <%= @script_name %> <%= @stop_cmd %>"
+<% unless @start_program.to_s == "" %>
+  start program = "<%= @start_program -%>"
+<% end %>
+<% unless @stop_program.to_s == "" %>
+  stop program = "<%= @stop_program -%>"
+<% end %>
 <% @http_checks.each do |check| -%>
   <%= check %>
 <% end -%>


### PR DESCRIPTION
Partial fix to allow openstack-monitoring take no action and monitor only for
rabbitmq.

Issues rcbops/chef-cookbooks#860 and rcbops/chef-cookbooks#909
